### PR TITLE
MVC Filter only add the stopwatch once

### DIFF
--- a/Ve.Metrics.StatsDClient.Mvc/StatsDActionFilter.cs
+++ b/Ve.Metrics.StatsDClient.Mvc/StatsDActionFilter.cs
@@ -18,7 +18,10 @@ namespace Ve.Metrics.StatsDClient.Mvc
 
         public override void OnActionExecuting(ActionExecutingContext filterContext)
         {
-            filterContext.HttpContext.Items.Add(StopwatchKey, Stopwatch.StartNew());
+            if (!filterContext.HttpContext.Items.Contains(StopwatchKey))
+            {
+                filterContext.HttpContext.Items.Add(StopwatchKey, Stopwatch.StartNew());
+            }
             base.OnActionExecuting(filterContext);
         }
 


### PR DESCRIPTION
It seems that calling `RenderAction()` re-uses the filterContext for the MVC actionFilters, which results in a duplicate key exception.

If we need to track explicitly child-requests then maybe we should be using a stack for storing multiple stopwatches, but the simple approach is just to perform a `.Contains()` check.