### PR TITLE
add more guard code to cope with a null stopwatch

### DIFF
--- a/Ve.Metrics.StatsDClient.Mvc/StatsDActionFilter.cs
+++ b/Ve.Metrics.StatsDClient.Mvc/StatsDActionFilter.cs
@@ -27,11 +27,16 @@ namespace Ve.Metrics.StatsDClient.Mvc
 
         public override void OnResultExecuted(ResultExecutedContext filterContext)
         {
-            var stopwatch = (Stopwatch)filterContext.HttpContext.Items[StopwatchKey];
-            stopwatch.Stop();
+            var routeData = GetRouteData(filterContext.HttpContext);
 
-            _statsd.LogCount("request", GetRouteData(filterContext.HttpContext));
-            _statsd.LogTiming("responses", stopwatch.ElapsedMilliseconds, GetRouteData(filterContext.HttpContext));
+            if (filterContext.HttpContext.Items.Contains(StopwatchKey))
+            {
+                var stopwatch = (Stopwatch)filterContext.HttpContext.Items[StopwatchKey];
+                stopwatch.Stop();
+                _statsd.LogTiming("responses", stopwatch.ElapsedMilliseconds, routeData);
+            }
+
+            _statsd.LogCount("request", routeData);
 
             if (filterContext.Exception != null)
             {


### PR DESCRIPTION
In cases where another filter has messed around with the HttpContext the Items dictionary could be in an unknown state and could result in the Stopwatch being missing.

Added some guard code to stop throwing exceptions in these cases