### PR TITLE
swallow and log exceptions from the client

### DIFF
--- a/Ve.Metrics.StatsDClient.Tests/VeStatsDClientShould.cs
+++ b/Ve.Metrics.StatsDClient.Tests/VeStatsDClientShould.cs
@@ -77,5 +77,50 @@ namespace Ve.Metrics.StatsDClient.Tests
             token.Dispose();
             _statsd.Verify(x => x.LogTiming(It.IsRegex("foo\\.bar\\,host\\=([A-Za-z0-9-]+)\\,datacenter\\=foo,foo\\=bar"), It.IsAny<long>()));
         }
+
+        [Test]
+        public void It_should_catch_runtime_errors_from_logcount()
+        {
+            _statsd.Setup(x => x.LogCount(It.IsAny<string>(), It.IsAny<int>()))
+                .Throws(new Exception("ohes noes, something broke"));
+
+            _client.LogCount("foo.bar");
+        }
+
+        [Test]
+        public void It_should_catch_runtime_errors_from_loggauge()
+        {
+            _statsd.Setup(x => x.LogGauge(It.IsAny<string>(), It.IsAny<int>()))
+                .Throws(new Exception("ohes noes, something broke"));
+
+            _client.LogCount("foo.bar");
+        }
+
+        [Test]
+        public void It_should_catch_runtime_errors_from_lograw()
+        {
+            _statsd.Setup(x => x.LogRaw(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<long?>()))
+                .Throws(new Exception("ohes noes, something broke"));
+
+            _client.LogCount("foo.bar");
+        }
+
+        [Test]
+        public void It_should_catch_runtime_errors_from_logcalendargram()
+        {
+            _statsd.Setup(x => x.LogCalendargram(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Throws(new Exception("ohes noes, something broke"));
+
+            _client.LogCount("foo.bar");
+        }
+
+        [Test]
+        public void It_should_catch_runtime_errors_from_logset()
+        {
+            _statsd.Setup(x => x.LogSet(It.IsAny<string>(), It.IsAny<int>()))
+                .Throws(new Exception("ohes noes, something broke"));
+
+            _client.LogCount("foo.bar");
+        }
     }
 }

--- a/Ve.Metrics.StatsDClient/Logger.cs
+++ b/Ve.Metrics.StatsDClient/Logger.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Ve.Metrics.StatsDClient
+{
+    public static class Logger
+    {
+        public static void Error(Exception e)
+        {
+            Trace.WriteLine(e);
+        }
+    }
+}

--- a/Ve.Metrics.StatsDClient/TimingToken.cs
+++ b/Ve.Metrics.StatsDClient/TimingToken.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Ve.Metrics.StatsDClient.Abstract;
 
@@ -9,7 +10,7 @@ namespace Ve.Metrics.StatsDClient
         private readonly IVeStatsDClient _client;
         private readonly string _name;
         private readonly Stopwatch _stopwatch;
-        private Dictionary<string, string> _tags;
+        private readonly Dictionary<string, string> _tags;
 
         public TimingToken(IVeStatsDClient client, string name, Dictionary<string,string> tags = null)
         {
@@ -22,7 +23,15 @@ namespace Ve.Metrics.StatsDClient
         public void Dispose()
         {
             _stopwatch.Stop();
-            _client.LogTiming(_name, _stopwatch.ElapsedMilliseconds, _tags);
+
+            try
+            {
+                _client.LogTiming(_name, _stopwatch.ElapsedMilliseconds, _tags);
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e);
+            }
         }
     }
 }

--- a/Ve.Metrics.StatsDClient/Ve.Metrics.StatsDClient.csproj
+++ b/Ve.Metrics.StatsDClient/Ve.Metrics.StatsDClient.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Logger.cs" />
     <Compile Include="StatsdConfig.cs" />
     <Compile Include="TimingToken.cs" />
     <Compile Include="VeStatsDClient.cs" />

--- a/Ve.Metrics.StatsDClient/VeStatsDClient.cs
+++ b/Ve.Metrics.StatsDClient/VeStatsDClient.cs
@@ -34,11 +34,23 @@ namespace Ve.Metrics.StatsDClient
             }
         }
 
+        private static void RunSafe(Action thing)
+        {
+            try
+            {
+                thing();
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e);
+            }
+        }
+
         public void LogCount(string name)
         {
             LogCount(name, 1);
         }
-
+        
         public void LogCount(string name, Dictionary<string, string> tags)
         {
             LogCount(name, 1, tags);
@@ -46,17 +58,20 @@ namespace Ve.Metrics.StatsDClient
 
         public void LogCount(string name, int count, Dictionary<string, string> tags = null)
         {
-            _statsd.LogCount(BuildName(name, tags), count);
+            RunSafe(
+                () => _statsd.LogCount(BuildName(name, tags), count));
         }
 
         public void LogTiming(string name, long milliseconds, Dictionary<string, string> tags = null)
         {
-            _statsd.LogTiming(BuildName(name, tags), milliseconds);
+            RunSafe(() =>
+                _statsd.LogTiming(BuildName(name, tags), milliseconds));
         }
 
         public void LogTiming(string name, int milliseconds, Dictionary<string, string> tags = null)
         {
-            _statsd.LogTiming(BuildName(name, tags), milliseconds);
+            RunSafe(() =>
+                _statsd.LogTiming(BuildName(name, tags), milliseconds));
         }
 
         public ITimingToken LogTiming(string name)
@@ -71,22 +86,26 @@ namespace Ve.Metrics.StatsDClient
 
         public void LogGauge(string name, int value, Dictionary<string, string> tags = null)
         {
-            _statsd.LogGauge(BuildName(name, tags), value);
+            RunSafe(() =>
+                _statsd.LogGauge(BuildName(name, tags), value));
         }
 
         public void LogCalendargram(string name, int value, string period, Dictionary<string, string> tags = null)
         {
-            _statsd.LogCalendargram(BuildName(name, tags), value, period);
+            RunSafe(() =>
+                _statsd.LogCalendargram(BuildName(name, tags), value, period));
         }
 
         public void LogCalendargram(string name, string value, string period, Dictionary<string, string> tags = null)
         {
-            _statsd.LogCalendargram(BuildName(name, tags), value, period);
+            RunSafe(() =>
+                _statsd.LogCalendargram(BuildName(name, tags), value, period));
         }
 
         public void LogRaw(string name, int value, string period, long? epoch = null, Dictionary<string, string> tags = null)
         {
-            _statsd.LogRaw(BuildName(name, tags), value, epoch);
+            RunSafe(() =>
+                _statsd.LogRaw(BuildName(name, tags), value, epoch));
         }
 
         private static string BuildName(string name, Dictionary<string, string> tags)


### PR DESCRIPTION
we shouldn't ever bubble them.

In future we might want to allow the user to register their own exception listener, but for now this will suffice